### PR TITLE
Provide more clear error when there's no jade file

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -135,8 +135,15 @@ function start(data, json) {
           console.log("  Using template: %s", template);
 
           // Determine and compile the template
-          var jadeFn = jade.compileFile(template);
+          try {
+            var jadeFn = jade.compileFile(template);
+          } catch(err) {
+            if(err.code === "ENOENT") {
+              err = new Error("There is no defined jade file for this markdown document");
+            }
 
+            throw err; // rethrow
+          }
           // Render to HTML.
           return jadeFn({
             $: markFile.normal.meta,


### PR DESCRIPTION
Catches a specific error when a jade file does not exist for a markdown file and provides a nice error message instead of "ENOENT, no such file or directory '.../templates/....jade"
